### PR TITLE
Fixed a bug that prints redundant line at the tail

### DIFF
--- a/ldig.c
+++ b/ldig.c
@@ -206,25 +206,36 @@ int list(const char *__restrict __file, appearance __app, unsigned char __args_l
     char __prefix_dir[__DPBS] = {0};
     char __name[__DPBS] = {0};
 
-    // If the input file is not a symbolic link.
+    // If --ignore argument detected.
     if ((__args_list & 0x2) == 0x2)
     {
         struct stat file_stat;
         lstat(__file, &file_stat);
-        if (!S_ISLNK(file_stat.st_mode))
+        if (!S_ISLNK(file_stat.st_mode)) // If the input file is not a symbolic link.
         {
-            if (__app == ap_list)           // In list-printing mode.
-                cprintf(ap_normal, "\e[A"); // Move arrow up.
-            return 0;
+            if ((__args_list & 0x10) == 0x10 && __app == ap_list) // If this is the last one and in list-printing mode.
+                cprintf(ap_normal, "\e[A");                       // Move arrow up to remove redundant line at the tail.
+            return 0;                                             // Note that if the last one isn't a symbolic link and ignored, there will be a redundant blank line at the tail.
+        }
+        else // If the input file is a symbolic link.
+        {
+            split(__file, __prefix_dir, __name);
+            rreadlink(__prefix_dir, __name, __app);
+
+            // To append a blank line after a chain in list-printing mode (excluding the last one).
+            if ((__args_list & 0x10) != 0x10 && __app == ap_list) // If this isn't the last one and in list-printing mode.
+                cprintf(ap_normal, "\n");
         }
     }
+    else // If --ignore argument not detected.
+    {
+        split(__file, __prefix_dir, __name);
+        rreadlink(__prefix_dir, __name, __app);
 
-    split(__file, __prefix_dir, __name);
-    rreadlink(__prefix_dir, __name, __app);
-
-    // To append a blank line after a chain in list-printing mode (excluding the last one).
-    if ((__args_list & 0x10) != 0x10 && __app == ap_list) // If this isn't the last one and in list-printing mode.
-        cprintf(ap_normal, "\n");
+        // To append a blank line after a chain in list-printing mode (excluding the last one).
+        if ((__args_list & 0x10) != 0x10 && __app == ap_list) // If this isn't the last one and in list-printing mode.
+            cprintf(ap_normal, "\n");
+    }
 
     return 0;
 }
@@ -261,13 +272,12 @@ There is NO WARRANTY, to the extent permitted by law.\n\
         __app = ap_list;
         break;
     case ARGP_KEY_ARG:
-
         if (__app == ap_list && state->argc == state->next) // (state->argc == state->next) means this arg is the last one.
             __args_list |= 0x10;
         list(arg, __app, __args_list);
         break;
     case ARGP_KEY_END:
-        if (state->arg_num == 0 && __args_list & 0x1 == 0) // If no path given and no --version argument detected.
+        if (state->arg_num == 0 && (__args_list & 0x1) == 0) // If no path given and no --version argument detected.
             argp_failure(state, 1, 0, "too few arguments");
         break;
     }

--- a/ldig.c
+++ b/ldig.c
@@ -198,16 +198,33 @@ int rreadlink(char *__restrict __prefix_dir, char *__restrict __name, appearance
  * 
  * @param __file The file to check.
  * @param __app The controller for printf behavior.
+ * @param __args_list The arguments transmission medium.
  * @return The return value will always be 0. 
  */
-int list(const char *__restrict __file, appearance __app)
+int list(const char *__restrict __file, appearance __app, unsigned char __args_list)
 {
     char __prefix_dir[__DPBS] = {0};
     char __name[__DPBS] = {0};
 
-    split(__file, __prefix_dir, __name);
+    // If the input file is not a symbolic link.
+    if ((__args_list & 0x2) == 0x2)
+    {
+        struct stat file_stat;
+        lstat(__file, &file_stat);
+        if (!S_ISLNK(file_stat.st_mode))
+        {
+            if (__app == ap_list)           // In list-printing mode.
+                cprintf(ap_normal, "\e[A"); // Move arrow up.
+            return 0;
+        }
+    }
 
+    split(__file, __prefix_dir, __name);
     rreadlink(__prefix_dir, __name, __app);
+
+    // To append a blank line after a chain in list-printing mode (excluding the last one).
+    if ((__args_list & 0x10) != 0x10 && __app == ap_list) // If this isn't the last one and in list-printing mode.
+        cprintf(ap_normal, "\n");
 
     return 0;
 }
@@ -217,32 +234,40 @@ parse_opt(int key, char *arg, struct argp_state *state)
 {
     // Reset the process's working directory to original for each arguments.
     chdir(__gcwd);
+
+    // The program behavior controller.
+    // x x x l  x x i v
+    static unsigned char __args_list = 0;
+
     static appearance __app = ap_normal; // Set default printf behavior.
+
     switch (key)
     {
-        static int v_ed = 0;
     case 'v': // Print version info.
         cprintf(ap_normal, "\
-ldig 0.0.2 (means not finished yet) - print symbolic links recursively.\n\
+ldig 0.0.3 (means not finished yet) - print symbolic links recursively.\n\
 Built for x86_64-pc-linux-gnu.\n\
 Written by Yibang Heng.\n\
 License GPLv3+: GNU GPL version 3 or later <http://gnu.org/licenses/gpl.html>\n\
 This is free software: you are free to change and redistribute it.\n\
 There is NO WARRANTY, to the extent permitted by law.\n\
 ");
-        v_ed = 1;
+        __args_list |= 0x1;
+        break;
+    case 'i': // Ignore if input file is not a symbolic link.
+        __args_list |= 0x2;
         break;
     case 'l': // List-printing mode (print one file per line).
         __app = ap_list;
         break;
     case ARGP_KEY_ARG:
-        list(arg, __app);
-        // To append a blank line after a chain in list-printing mode (excluding the last one).
-        if (__app == ap_list && state->argc != state->next) // (state->argc == state->next) means this arg is the last one.
-            cprintf(ap_normal, "\n");
+
+        if (__app == ap_list && state->argc == state->next) // (state->argc == state->next) means this arg is the last one.
+            __args_list |= 0x10;
+        list(arg, __app, __args_list);
         break;
     case ARGP_KEY_END:
-        if (state->arg_num == 0 && v_ed == 0) // If no path given.
+        if (state->arg_num == 0 && __args_list & 0x1 == 0) // If no path given and no --version argument detected.
             argp_failure(state, 1, 0, "too few arguments");
         break;
     }
@@ -256,6 +281,7 @@ int main(int argc, char **argv)
     struct argp_option options[] =
         {
             {"version", 'v', 0, 0, "Print the version number of make and exit"},
+            {"ignore", 'i', 0, 0, "Ignore if input file is not a symbolic link"},
             {"list", 'l', 0, 0, "List one file per line"},
             {0},
         };


### PR DESCRIPTION
A redundant line will be printed if program runs with --ignore and the last one is not a symbolic link (that means, it will be ignored and not printed). Now fixed.  